### PR TITLE
Apply alias on select columns when it is used on tables

### DIFF
--- a/Flepper.QueryBuilder/Base/BaseFlepperQueryBuilder.cs
+++ b/Flepper.QueryBuilder/Base/BaseFlepperQueryBuilder.cs
@@ -1,12 +1,13 @@
-﻿using System;
+﻿using Flepper.QueryBuilder.Utils;
+using System;
 using System.Collections.Generic;
 using System.Text;
-using Flepper.QueryBuilder.Utils;
 
 namespace Flepper.QueryBuilder.Base
 {
     internal abstract class BaseQueryBuilder : IQueryCommand
     {
+        protected SqlColumn[] Columns;
         protected readonly StringBuilder Command;
         protected readonly IDictionary<string, object> Parameters;
 
@@ -16,10 +17,11 @@ namespace Flepper.QueryBuilder.Base
             Parameters = new Dictionary<string, object>();
         }
 
-        protected BaseQueryBuilder(StringBuilder command, IDictionary<string, object> parameters)
+        protected BaseQueryBuilder(StringBuilder command, IDictionary<string, object> parameters, SqlColumn[] columns)
         {
             Command = command;
             Parameters = parameters;
+            Columns = columns;
         }
 
         public string Build()
@@ -30,10 +32,10 @@ namespace Flepper.QueryBuilder.Base
 
         public TEnd To<TEnd>()
             where TEnd : IQueryCommand
-            => (TEnd)Activator.CreateInstance(typeof(TEnd), Command, Parameters);
+            => (TEnd)Activator.CreateInstance(typeof(TEnd), Command, Parameters, Columns);
 
-        public TEnd To<TEnd>(Func<StringBuilder, IDictionary<string, object>, TEnd> creator)
-            => creator(Command, Parameters);
+        public TEnd To<TEnd>(Func<StringBuilder, IDictionary<string, object>, SqlColumn[], TEnd> creator)
+            => creator(Command, Parameters, Columns);
 
         protected int AddParameters(params object[] values)
         {

--- a/Flepper.QueryBuilder/Base/BaseFlepperQueryBuilder.cs
+++ b/Flepper.QueryBuilder/Base/BaseFlepperQueryBuilder.cs
@@ -1,7 +1,7 @@
-﻿using Flepper.QueryBuilder.Utils;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using Flepper.QueryBuilder.Utils;
 
 namespace Flepper.QueryBuilder.Base
 {

--- a/Flepper.QueryBuilder/Base/SqlColumn.cs
+++ b/Flepper.QueryBuilder/Base/SqlColumn.cs
@@ -67,6 +67,12 @@ namespace Flepper.QueryBuilder.Base
                 if(!Column.EndsWith("]")) Column = $"{Column}]";
             }
 
+            if(TableAlias != null)
+            {
+                if (!TableAlias.StartsWith("[")) TableAlias = $"[{TableAlias}";
+                if (!TableAlias.EndsWith("]")) TableAlias = $"{TableAlias}]";
+            }
+
             if (!IsNullOrWhiteSpace(Alias) && !Column.Contains(ALIAS)) Column = $"{Column} AS {Alias.Trim()}";
             if (!IsNullOrWhiteSpace(TableAlias) && !Column.Contains(TABLE_ALIAS)) Column = $"{TableAlias}.{Column}";
         }

--- a/Flepper.QueryBuilder/Base/SqlColumn.cs
+++ b/Flepper.QueryBuilder/Base/SqlColumn.cs
@@ -1,6 +1,6 @@
-﻿using Flepper.QueryBuilder.Utils.Extensions;
-using System;
+﻿using System;
 using System.Runtime.CompilerServices;
+using Flepper.QueryBuilder.Utils.Extensions;
 using static System.String;
 namespace Flepper.QueryBuilder.Base
 {

--- a/Flepper.QueryBuilder/Base/SqlColumn.cs
+++ b/Flepper.QueryBuilder/Base/SqlColumn.cs
@@ -66,12 +66,7 @@ namespace Flepper.QueryBuilder.Base
             => source.IndexOf(ALIAS, StringComparison.OrdinalIgnoreCase) > 0;
 
         private static string GetTableAlias(string source)
-        {
-            if (source.Contains("."))
-                return source.Split(new[] { '.' })[0];
-
-            return null;
-        }
+            => source?.Split('.')[0];
 
         /// <summary>
         /// Shallow copy of the instance

--- a/Flepper.QueryBuilder/Base/SqlColumn.cs
+++ b/Flepper.QueryBuilder/Base/SqlColumn.cs
@@ -15,16 +15,24 @@ namespace Flepper.QueryBuilder.Base
         /// <summary>
         /// the column name or sql function.
         /// </summary>
-        protected string Column { get; set; }
-        
+        public string Column { get; set; }
+
         /// <summary>
         /// the column alias
         /// </summary>
-        protected string Alias { get; }
+        public string Alias { get; }
+
+        /// <summary>
+        /// the table alias. Ex: [t1].[Column1] t1 the alias of the table
+        /// </summary>
+        public string TableAlias { get; }
 
         internal SqlColumn(string column)
         {
             if (IsNullOrWhiteSpace(column)) throw new ArgumentNullException($"{nameof(column)} cannot be null or empty");
+
+            TableAlias = GetTableAlias(column);
+
             if (ContainsAlias(column))
                 (Column, Alias) = column.Split(AliasSplitter, StringSplitOptions.RemoveEmptyEntries);
             else
@@ -56,5 +64,22 @@ namespace Flepper.QueryBuilder.Base
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ContainsAlias(string source)
             => source.IndexOf(ALIAS, StringComparison.OrdinalIgnoreCase) > 0;
+
+        private static string GetTableAlias(string source)
+        {
+            if (source.Contains("."))
+                return source.Split(new[] { '.' })[0];
+
+            return null;
+        }
+
+        /// <summary>
+        /// Shallow copy of the instance
+        /// </summary>
+        /// <returns></returns>
+        public SqlColumn Clone()
+        {
+            return (SqlColumn)MemberwiseClone();
+        }
     }
 }

--- a/Flepper.QueryBuilder/Commands/Extensions/DeleteCommandExtensions.cs
+++ b/Flepper.QueryBuilder/Commands/Extensions/DeleteCommandExtensions.cs
@@ -12,6 +12,6 @@
         /// <param name="table">Table name</param>
         /// <returns></returns>
         public static IFromCommand From(this IDeleteCommand deleteCommand, string table)
-            => deleteCommand.To((s, p) => new FromCommand(s, p, table));
+            => deleteCommand.To((s, p, c) => new FromCommand(s, p, c, table));
     }
 }

--- a/Flepper.QueryBuilder/Commands/Extensions/SelectCommandExtensions.cs
+++ b/Flepper.QueryBuilder/Commands/Extensions/SelectCommandExtensions.cs
@@ -13,7 +13,7 @@
         /// <param name="table">Table name</param>
         /// <returns></returns>
         public static IFromCommand From(this ISelectCommand selectCommand, string schema, string table)
-            => selectCommand.To((s, p) => new FromCommand(s, p, schema, table));
+            => selectCommand.To((s, p, c) => new FromCommand(s, p, c, schema, table));
 
 
         /// <summary>
@@ -23,7 +23,7 @@
         /// <param name="table">Table name</param>
         /// <returns></returns>
         public static IFromCommand From(this ISelectCommand selectCommand, string table)
-            => selectCommand.To((s, p) => new FromCommand(s, p, table));
+            => selectCommand.To((s, p, c) => new FromCommand(s, p, c, table));
 
         /// <summary>
         /// Add Top Command
@@ -32,6 +32,6 @@
         /// <param name="size">Size of records</param>
         /// <returns></returns>
         public static ITopCommand Top(this ISelectCommand selectCommand, int size = 1)
-            => selectCommand.To((s, p) => new TopCommand(s, p, size));
+            => selectCommand.To((s, p, c) => new TopCommand(s, p, c, size));
     }
 }

--- a/Flepper.QueryBuilder/Commands/Extensions/TopCommandExtensions.cs
+++ b/Flepper.QueryBuilder/Commands/Extensions/TopCommandExtensions.cs
@@ -13,7 +13,7 @@
         /// <param name="table">Table name</param>
         /// <returns></returns>
         public static IFromCommand From(this ITopCommand topCommand, string schema, string table)
-            => topCommand.To((s, p) => new FromCommand(s, p, schema, table));
+            => topCommand.To((s, p, c) => new FromCommand(s, p, c, schema, table));
 
         /// <summary>
         /// Add From to query
@@ -22,6 +22,6 @@
         /// <param name="table">Table name</param>
         /// <returns></returns>
         public static IFromCommand From(this ITopCommand topCommand, string table)
-            => topCommand.To((s, p) => new FromCommand(s, p, table));
+            => topCommand.To((s, p, c) => new FromCommand(s, p, c, table));
     }
 }

--- a/Flepper.QueryBuilder/Commands/FromCommand.cs
+++ b/Flepper.QueryBuilder/Commands/FromCommand.cs
@@ -6,12 +6,12 @@ namespace Flepper.QueryBuilder
 {
     internal class FromCommand : BaseQueryBuilder, IFromCommand
     {
-        public FromCommand(StringBuilder command, IDictionary<string, object> parameters, string schema, string table) 
-            : base(command, parameters)
+        public FromCommand(StringBuilder command, IDictionary<string, object> parameters, SqlColumn[] columns, string schema, string table) 
+            : base(command, parameters, columns)
             => Command.AppendFormat("FROM [{0}].[{1}] ", schema, table);
 
-        public FromCommand(StringBuilder command, IDictionary<string, object> parameters, string table) 
-            : base(command, parameters)
+        public FromCommand(StringBuilder command, IDictionary<string, object> parameters, SqlColumn[] columns, string table) 
+            : base(command, parameters, columns)
             => Command.AppendFormat("FROM [{0}] ", table);
     }
 }

--- a/Flepper.QueryBuilder/Commands/InsertCommand.cs
+++ b/Flepper.QueryBuilder/Commands/InsertCommand.cs
@@ -1,6 +1,6 @@
-﻿using Flepper.QueryBuilder.Base;
+﻿using System.Linq;
+using Flepper.QueryBuilder.Base;
 using Flepper.QueryBuilder.Utils.Extensions;
-using System.Linq;
 
 namespace Flepper.QueryBuilder
 {

--- a/Flepper.QueryBuilder/Commands/Interfaces/IQueryCommand.cs
+++ b/Flepper.QueryBuilder/Commands/Interfaces/IQueryCommand.cs
@@ -1,7 +1,7 @@
-﻿using Flepper.QueryBuilder.Base;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using Flepper.QueryBuilder.Base;
 
 namespace Flepper.QueryBuilder
 {

--- a/Flepper.QueryBuilder/Commands/Interfaces/IQueryCommand.cs
+++ b/Flepper.QueryBuilder/Commands/Interfaces/IQueryCommand.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Flepper.QueryBuilder.Base;
+using System;
 using System.Collections.Generic;
 using System.Text;
 
@@ -33,6 +34,6 @@ namespace Flepper.QueryBuilder
         /// </summary>
         /// <typeparam name="TEnd"></typeparam>
         /// <returns></returns>
-        TEnd To<TEnd>(Func<StringBuilder, IDictionary<string, object>, TEnd> creator);
+        TEnd To<TEnd>(Func<StringBuilder, IDictionary<string, object>, SqlColumn[], TEnd> creator);
     }
 }

--- a/Flepper.QueryBuilder/Commands/SelectCommand.cs
+++ b/Flepper.QueryBuilder/Commands/SelectCommand.cs
@@ -1,7 +1,7 @@
-﻿using Flepper.QueryBuilder.Base;
-using Flepper.QueryBuilder.Utils.Extensions;
-using System;
+﻿using System;
 using System.Linq;
+using Flepper.QueryBuilder.Base;
+using Flepper.QueryBuilder.Utils.Extensions;
 
 namespace Flepper.QueryBuilder
 {

--- a/Flepper.QueryBuilder/Commands/SelectCommand.cs
+++ b/Flepper.QueryBuilder/Commands/SelectCommand.cs
@@ -1,20 +1,26 @@
-﻿using System;
-using System.Linq;
-using Flepper.QueryBuilder.Base;
-using Flepper.QueryBuilder.Operators.SqlFunctions;
+﻿using Flepper.QueryBuilder.Base;
 using Flepper.QueryBuilder.Utils.Extensions;
+using System;
+using System.Linq;
 
 namespace Flepper.QueryBuilder
 {
     internal class SelectCommand : BaseQueryBuilder, ISelectCommand
     {
-        public SelectCommand() 
-            => Command.Append("SELECT * ");
+        public SelectCommand()
+        {
+            Columns = new[] { (SqlColumn)"*" };
+            Command.Append("SELECT * ");
+        }
 
-       public SelectCommand(params SqlColumn[] columns)
+
+        public SelectCommand(params SqlColumn[] columns)
         {
             if (columns.Any(c => c == null))
                 throw new ArgumentNullException(nameof(columns), "All columns names should not be null");
+
+            Columns = columns;
+
             Command.AppendFormat("SELECT {0}", columns.Select(c => c.ToString()).JoinColumns());
         }
     }

--- a/Flepper.QueryBuilder/Commands/TopCommand.cs
+++ b/Flepper.QueryBuilder/Commands/TopCommand.cs
@@ -6,7 +6,7 @@ namespace Flepper.QueryBuilder
 {
     internal class TopCommand : BaseQueryBuilder, ITopCommand
     {
-        public TopCommand(StringBuilder command, IDictionary<string, object> parameters, int size = 1) : base(command, parameters)
+        public TopCommand(StringBuilder command, IDictionary<string, object> parameters, SqlColumn[] columns, int size = 1) : base(command, parameters, columns)
             => Command.Replace("SELECT ", $"SELECT TOP {size} ");
     }
 }

--- a/Flepper.QueryBuilder/Filters/WhereFilter.cs
+++ b/Flepper.QueryBuilder/Filters/WhereFilter.cs
@@ -6,7 +6,7 @@ namespace Flepper.QueryBuilder
 {
     internal class WhereFilter : BaseQueryBuilder, IWhereFilter
     {
-        public WhereFilter(StringBuilder command, IDictionary<string, object> parameters) : base(command, parameters)
+        public WhereFilter(StringBuilder command, IDictionary<string, object> parameters, SqlColumn[] columns) : base(command, parameters, columns)
         {
         }
 

--- a/Flepper.QueryBuilder/FlepperQueryBuilder.cs
+++ b/Flepper.QueryBuilder/FlepperQueryBuilder.cs
@@ -1,7 +1,8 @@
-﻿using System;
-using System.Linq.Expressions;
+﻿using Flepper.QueryBuilder.Base;
 using Flepper.QueryBuilder.Utils;
-using Flepper.QueryBuilder.Base;
+using System;
+using System.Linq.Expressions;
+using System.Linq;
 
 namespace Flepper.QueryBuilder
 {

--- a/Flepper.QueryBuilder/FlepperQueryBuilder.cs
+++ b/Flepper.QueryBuilder/FlepperQueryBuilder.cs
@@ -1,8 +1,7 @@
-﻿using Flepper.QueryBuilder.Base;
-using Flepper.QueryBuilder.Utils;
-using System;
+﻿using System;
 using System.Linq.Expressions;
-using System.Linq;
+using Flepper.QueryBuilder.Base;
+using Flepper.QueryBuilder.Utils;
 
 namespace Flepper.QueryBuilder
 {

--- a/Flepper.QueryBuilder/Join/Join.cs
+++ b/Flepper.QueryBuilder/Join/Join.cs
@@ -6,7 +6,7 @@ namespace Flepper.QueryBuilder
 {
     internal class Join : BaseQueryBuilder, IJoin
     {
-        public Join(StringBuilder command, IDictionary<string, object> parameters) : base(command, parameters)
+        public Join(StringBuilder command, IDictionary<string, object> parameters, SqlColumn[] columns) : base(command, parameters, columns)
         {
         }
 

--- a/Flepper.QueryBuilder/Join/Operators/Comparison/JoinComparisonOperators.cs
+++ b/Flepper.QueryBuilder/Join/Operators/Comparison/JoinComparisonOperators.cs
@@ -6,7 +6,7 @@ namespace Flepper.QueryBuilder
 {
     internal class JoinComparisonOperators : BaseQueryBuilder, IJoinComparisonOperators
     {
-        public JoinComparisonOperators(StringBuilder command, IDictionary<string, object> parameters) : base(command, parameters)
+        public JoinComparisonOperators(StringBuilder command, IDictionary<string, object> parameters, SqlColumn[] columns) : base(command, parameters, columns)
         {
         }
 

--- a/Flepper.QueryBuilder/Join/Operators/Intersection/OnOperator.cs
+++ b/Flepper.QueryBuilder/Join/Operators/Intersection/OnOperator.cs
@@ -6,7 +6,7 @@ namespace Flepper.QueryBuilder
 {
     internal class OnOperator : BaseQueryBuilder, IOnOperator
     {
-        public OnOperator(StringBuilder command, IDictionary<string, object> parameters) : base(command, parameters)
+        public OnOperator(StringBuilder command, IDictionary<string, object> parameters, SqlColumn[] columns) : base(command, parameters, columns)
         {
         }
 

--- a/Flepper.QueryBuilder/Operators/Alias/AliasOperator.cs
+++ b/Flepper.QueryBuilder/Operators/Alias/AliasOperator.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using Flepper.QueryBuilder.Base;
 
@@ -12,23 +14,12 @@ namespace Flepper.QueryBuilder
 
         public IAliasOperator As(string alias)
         {
-            var command = new StringBuilder(Command.ToString());
+            Columns = Columns.Select(c => c.TableAlias != null ? c : new SqlColumn($"[{alias}].{c}")).ToArray();
 
-            for (int i = 0; i < Columns.Length; i++)
-            {
-                var c = Columns[i];
-
-                if (c.TableAlias == null)
-                {
-                    var columnWithAlias = $"[{alias}].{c}";
-                    Columns[i] = new SqlColumn(columnWithAlias);
-
-                    command = command.Replace(c, columnWithAlias);
-                }
-            }
+            var command = Command.ToString();
 
             Command.Clear();
-            Command.Append(command.ToString());
+            Command.Append($"SELECT {string.Join(",", Columns.Select(c => c.ToString()))} FROM {command.Split(new[] { "FROM " }, StringSplitOptions.RemoveEmptyEntries)[1].Trim()} ");
 
             Command.AppendFormat("{0} ", alias);
 

--- a/Flepper.QueryBuilder/Operators/Alias/AliasOperator.cs
+++ b/Flepper.QueryBuilder/Operators/Alias/AliasOperator.cs
@@ -1,6 +1,6 @@
-﻿using Flepper.QueryBuilder.Base;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Text;
+using Flepper.QueryBuilder.Base;
 
 namespace Flepper.QueryBuilder
 {

--- a/Flepper.QueryBuilder/Operators/Alias/AliasOperator.cs
+++ b/Flepper.QueryBuilder/Operators/Alias/AliasOperator.cs
@@ -1,18 +1,37 @@
-﻿using System.Collections.Generic;
+﻿using Flepper.QueryBuilder.Base;
+using System.Collections.Generic;
 using System.Text;
-using Flepper.QueryBuilder.Base;
 
 namespace Flepper.QueryBuilder
 {
     internal class AliasOperator : BaseQueryBuilder, IAliasOperator
     {
-        public AliasOperator(StringBuilder command, IDictionary<string, object> parameters) : base(command, parameters)
+        public AliasOperator(StringBuilder command, IDictionary<string, object> parameters, SqlColumn[] columns) : base(command, parameters, columns)
         {
         }
 
         public IAliasOperator As(string alias)
         {
+            var command = new StringBuilder(Command.ToString());
+
+            for (int i = 0; i < Columns.Length; i++)
+            {
+                var c = Columns[i];
+
+                if (c.TableAlias == null)
+                {
+                    var columnWithAlias = $"[{alias}].{c}";
+                    Columns[i] = new SqlColumn(columnWithAlias);
+
+                    command = command.Replace(c, columnWithAlias);
+                }
+            }
+
+            Command.Clear();
+            Command.Append(command.ToString());
+
             Command.AppendFormat("{0} ", alias);
+
             return this;
         }
     }

--- a/Flepper.QueryBuilder/Operators/Comparison/ComparisonOperators.cs
+++ b/Flepper.QueryBuilder/Operators/Comparison/ComparisonOperators.cs
@@ -6,7 +6,7 @@ namespace Flepper.QueryBuilder
 {
     internal class ComparisonOperators : BaseQueryBuilder, IComparisonOperators
     {
-        public ComparisonOperators(StringBuilder command, IDictionary<string, object> parameters) : base(command, parameters)
+        public ComparisonOperators(StringBuilder command, IDictionary<string, object> parameters, SqlColumn[] columns) : base(command, parameters, columns)
         {
         }
 

--- a/Flepper.QueryBuilder/Operators/Grouping/Grouping.cs
+++ b/Flepper.QueryBuilder/Operators/Grouping/Grouping.cs
@@ -1,7 +1,7 @@
-﻿using Flepper.QueryBuilder.Base;
-using Flepper.QueryBuilder.Operators.Grouping.Interfaces;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Text;
+using Flepper.QueryBuilder.Base;
+using Flepper.QueryBuilder.Operators.Grouping.Interfaces;
 
 namespace Flepper.QueryBuilder.Operators.Grouping
 {

--- a/Flepper.QueryBuilder/Operators/Grouping/Grouping.cs
+++ b/Flepper.QueryBuilder/Operators/Grouping/Grouping.cs
@@ -8,7 +8,7 @@ namespace Flepper.QueryBuilder.Operators.Grouping
     internal class Grouping : BaseQueryBuilder, IGrouping
     {
 
-        public Grouping(StringBuilder command, IDictionary<string, object> parameters) : base(command, parameters)
+        public Grouping(StringBuilder command, IDictionary<string, object> parameters, SqlColumn[] columns) : base(command, parameters, columns)
         {
 
         }

--- a/Flepper.QueryBuilder/Operators/Logical/LogicalOperators.cs
+++ b/Flepper.QueryBuilder/Operators/Logical/LogicalOperators.cs
@@ -6,7 +6,7 @@ namespace Flepper.QueryBuilder
 {
     internal class LogicalOperators : BaseQueryBuilder, ILogicalOperators
     {
-        public LogicalOperators(StringBuilder command, IDictionary<string, object> parameters) : base(command, parameters)
+        public LogicalOperators(StringBuilder command, IDictionary<string, object> parameters, SqlColumn[] columns) : base(command, parameters, columns)
         {
         }
 

--- a/Flepper.QueryBuilder/Operators/Set/SetOperator.cs
+++ b/Flepper.QueryBuilder/Operators/Set/SetOperator.cs
@@ -6,7 +6,7 @@ namespace Flepper.QueryBuilder
 {
     internal class SetOperator : BaseQueryBuilder, ISetOperator
     {
-        public SetOperator(StringBuilder command, IDictionary<string, object> parameters) : base(command, parameters)
+        public SetOperator(StringBuilder command, IDictionary<string, object> parameters, SqlColumn[] columns) : base(command, parameters, columns)
         {
         }
 

--- a/Flepper.QueryBuilder/Operators/SqlFunctions/CountOperator.cs
+++ b/Flepper.QueryBuilder/Operators/SqlFunctions/CountOperator.cs
@@ -1,6 +1,6 @@
 ﻿using System;
-using static System.String;
 using Flepper.QueryBuilder.Base;
+using static System.String;
 namespace Flepper.QueryBuilder.Operators.SqlFunctions
 {
     /// <summary>

--- a/Flepper.QueryBuilder/Operators/Values/ValuesOperator.cs
+++ b/Flepper.QueryBuilder/Operators/Values/ValuesOperator.cs
@@ -7,7 +7,7 @@ namespace Flepper.QueryBuilder
 {
     internal class ValuesOperator : BaseQueryBuilder, IValuesOperator
     {
-        public ValuesOperator(StringBuilder command, IDictionary<string, object> parameters) : base(command, parameters)
+        public ValuesOperator(StringBuilder command, IDictionary<string, object> parameters, SqlColumn[] columns) : base(command, parameters, columns)
         {
         }
 

--- a/Flepper.QueryBuilder/Sort/Sort.cs
+++ b/Flepper.QueryBuilder/Sort/Sort.cs
@@ -6,7 +6,7 @@ namespace Flepper.QueryBuilder
 {
     internal class Sort : BaseQueryBuilder, ISort, ISortThen
     {
-        public Sort(StringBuilder command, IDictionary<string, object> parameters) : base(command, parameters)
+        public Sort(StringBuilder command, IDictionary<string, object> parameters, SqlColumn[] columns) : base(command, parameters, columns)
         {
         }
 

--- a/Flepper.QueryBuilder/Sort/Sort.cs
+++ b/Flepper.QueryBuilder/Sort/Sort.cs
@@ -1,6 +1,6 @@
-﻿using Flepper.QueryBuilder.Base;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Text;
+using Flepper.QueryBuilder.Base;
 
 namespace Flepper.QueryBuilder
 {

--- a/Flepper.QueryBuilder/Utils/Cache.cs
+++ b/Flepper.QueryBuilder/Utils/Cache.cs
@@ -1,10 +1,10 @@
-﻿using System;
+﻿using Flepper.QueryBuilder.Base;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
-using Flepper.QueryBuilder.Base;
 
 namespace Flepper.QueryBuilder.Utils
 {
@@ -24,10 +24,10 @@ namespace Flepper.QueryBuilder.Utils
             where T : class
         {
             if (newLambdaExpression.Body is NewExpression newExpression)
-                return HandleNewExpression(newExpression);
+                return HandleNewExpression(newExpression).Select(item => item.Clone()).ToArray();
 
             if (newLambdaExpression.Body is MemberExpression memberExpression && memberExpression.Member is PropertyInfo propertyInfo)
-                return HandleProperty(propertyInfo, newLambdaExpression.ToString());
+                return HandleProperty(propertyInfo, newLambdaExpression.ToString()).Select(item => item.Clone()).ToArray();
 
             throw new NotSupportedException(NOT_SUPPORTED_MESSAGE);
         }
@@ -38,6 +38,7 @@ namespace Flepper.QueryBuilder.Utils
 
             data = getProperties();
             DtoProperties.TryAdd(type, data);
+
             return data;
         }
 

--- a/Flepper.QueryBuilder/Utils/Cache.cs
+++ b/Flepper.QueryBuilder/Utils/Cache.cs
@@ -24,10 +24,10 @@ namespace Flepper.QueryBuilder.Utils
             where T : class
         {
             if (newLambdaExpression.Body is NewExpression newExpression)
-                return HandleNewExpression(newExpression).Select(item => item.Clone()).ToArray();
+                return HandleNewExpression(newExpression);
 
             if (newLambdaExpression.Body is MemberExpression memberExpression && memberExpression.Member is PropertyInfo propertyInfo)
-                return HandleProperty(propertyInfo, newLambdaExpression.ToString()).Select(item => item.Clone()).ToArray();
+                return HandleProperty(propertyInfo, newLambdaExpression.ToString());
 
             throw new NotSupportedException(NOT_SUPPORTED_MESSAGE);
         }

--- a/Flepper.QueryBuilder/Utils/Cache.cs
+++ b/Flepper.QueryBuilder/Utils/Cache.cs
@@ -1,10 +1,10 @@
-﻿using Flepper.QueryBuilder.Base;
-using System;
+﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using Flepper.QueryBuilder.Base;
 
 namespace Flepper.QueryBuilder.Utils
 {

--- a/Flepper.Tests.Unit/QueryBuilder/Commands/JoinTests.cs
+++ b/Flepper.Tests.Unit/QueryBuilder/Commands/JoinTests.cs
@@ -21,6 +21,19 @@ namespace Flepper.Tests.Unit.QueryBuilder.Commands
         }
 
         [Fact]
+        public void ShouldReturnInnerJoinStatementWishTableAlias()
+        {
+            FlepperQueryBuilder.Select("t1.c1", "t2.c1")
+               .From("Table1").As("t1")
+               .InnerJoin("Table2").As("t2")
+               .On("t1", "c1").EqualTo("t2", "c1")
+               .Build()
+               .Trim()
+               .Should()
+               .Be("SELECT [t1].[c1],[t2].[c1] FROM [Table1] t1 INNER JOIN [Table2] t2 ON t1.[c1] = t2.[c1]");
+        }
+
+        [Fact]
         public void ShouldReturnInnerJoinWithOnEqualStatement()
         {
             FlepperQueryBuilder.Select()

--- a/Flepper.Tests.Unit/QueryBuilder/Commands/OrderByCommandTests.cs
+++ b/Flepper.Tests.Unit/QueryBuilder/Commands/OrderByCommandTests.cs
@@ -67,7 +67,7 @@ namespace Flepper.Tests.Unit.QueryBuilder.Commands
                 .Query
                 .Trim()
                 .Should()
-                .Be("SELECT [Id],[Name],[Birthday] FROM [user] t1 WHERE [Name] = @p0 ORDER BY [Name], [t1].[Birthday]");
+                .Be("SELECT [t1].[Id],[t1].[Name],[t1].[Birthday] FROM [user] t1 WHERE [Name] = @p0 ORDER BY [Name], [t1].[Birthday]");
 
             dynamic parameters = queryResult.Parameters;
 
@@ -109,7 +109,7 @@ namespace Flepper.Tests.Unit.QueryBuilder.Commands
                 .Query
                 .Trim()
                 .Should()
-                .Be("SELECT [Id],[Name] FROM [user] t1 INNER JOIN [address] t2 ON t2.[column1] = t1.[column2] WHERE [Name] = @p0 ORDER BY [t1].[Name]");
+                .Be("SELECT [t1].[Id],[t1].[Name] FROM [user] t1 INNER JOIN [address] t2 ON t2.[column1] = t1.[column2] WHERE [Name] = @p0 ORDER BY [t1].[Name]");
 
             dynamic parameters = queryResult.Parameters;
 
@@ -131,7 +131,7 @@ namespace Flepper.Tests.Unit.QueryBuilder.Commands
                 .Query
                 .Trim()
                 .Should()
-                .Be("SELECT [Id],[Name],[Birthday] FROM [user] t1 INNER JOIN [address] t2 ON t2.[column1] = t1.[column2] WHERE [Name] = @p0 ORDER BY [t1].[Name] DESC, [t1].[Birthday] DESC");
+                .Be("SELECT [t1].[Id],[t1].[Name],[t1].[Birthday] FROM [user] t1 INNER JOIN [address] t2 ON t2.[column1] = t1.[column2] WHERE [Name] = @p0 ORDER BY [t1].[Name] DESC, [t1].[Birthday] DESC");
 
             dynamic parameters = queryResult.Parameters;
 

--- a/Flepper.Tests.Unit/QueryBuilder/Commands/SelectCommandTests.cs
+++ b/Flepper.Tests.Unit/QueryBuilder/Commands/SelectCommandTests.cs
@@ -1,8 +1,8 @@
-﻿using System;
-using System.Linq;
-using Flepper.QueryBuilder;
+﻿using Flepper.QueryBuilder;
 using Flepper.QueryBuilder.Utils;
 using FluentAssertions;
+using System;
+using System.Linq;
 using Xunit;
 using static Flepper.QueryBuilder.FlepperQueryFunction;
 namespace Flepper.Tests.Unit.QueryBuilder.Commands
@@ -256,13 +256,22 @@ namespace Flepper.Tests.Unit.QueryBuilder.Commands
                 .Select("Name", "Age")
                 .From("User")
                 .GroupBy("Age")
-                .BuildWithParameters();
-
-            queryResult
+                .BuildWithParameters()
                 .Query
                 .Trim()
                 .Should()
-                .Be("SELECT [Name],[Age] FROM [User] GROUP BY [Age]");
+                .Be("SELECT [Name],[Age] FROM [User] GROUP BY [Age]"); ;
+        }
+
+        [Fact]
+        public void ShouldCreateSelectWithTableAliasOnSelectedColumns()
+        {
+            FlepperQueryBuilder.Select("Name")
+                .From("Table1").As("t1")
+                .Build()
+                .Trim()
+                .Should()
+                .Be("SELECT [t1].[Name] FROM [Table1] t1");
         }
 
         [Fact]

--- a/Flepper.Tests.Unit/QueryBuilder/Commands/SelectCommandTests.cs
+++ b/Flepper.Tests.Unit/QueryBuilder/Commands/SelectCommandTests.cs
@@ -1,8 +1,8 @@
-﻿using Flepper.QueryBuilder;
+﻿using System;
+using System.Linq;
+using Flepper.QueryBuilder;
 using Flepper.QueryBuilder.Utils;
 using FluentAssertions;
-using System;
-using System.Linq;
 using Xunit;
 using static Flepper.QueryBuilder.FlepperQueryFunction;
 namespace Flepper.Tests.Unit.QueryBuilder.Commands

--- a/Flepper.Tests.Unit/QueryBuilder/Commands/SqlColumnTests.cs
+++ b/Flepper.Tests.Unit/QueryBuilder/Commands/SqlColumnTests.cs
@@ -16,6 +16,38 @@ namespace Flepper.Tests.Unit.QueryBuilder.Commands
         }
 
         [Fact]
+        public void ShouldCreateColumnWithAlias()
+        {
+            var column = new SqlColumn("Column as C");
+
+            column.ToString().Should().Be("[Column] AS C");
+        }
+
+        [Fact]
+        public void ShouldCreateColumnWithTableAlias()
+        {
+            var column = new SqlColumn("t1.Column");
+
+            column.ToString().Should().Be("[t1].[Column]");
+        }
+
+        [Fact]
+        public void ShouldCreateColumnWithAliasAndTableAlias()
+        {
+            var column = new SqlColumn("t1.Column as c");
+
+            column.ToString().Should().Be("[t1].[Column] AS c");
+        }
+
+        [Fact]
+        public void ShoudNotAddBracketsWhenColumnIsAsterisk()
+        {
+            var column = new SqlColumn("t1.*");
+
+            column.ToString().Should().Be("[t1].*");
+        }
+
+        [Fact]
         public void ShouldCreateRegularColumnWithAsUpperCamelCase()
         {
             var column = new SqlColumn("Column As cl");

--- a/Flepper.Tests.Unit/QueryBuilder/Commands/SqlColumnTests.cs
+++ b/Flepper.Tests.Unit/QueryBuilder/Commands/SqlColumnTests.cs
@@ -1,6 +1,6 @@
-﻿using Flepper.QueryBuilder.Base;
+﻿using System.Linq;
+using Flepper.QueryBuilder.Base;
 using FluentAssertions;
-using System.Linq;
 using Xunit;
 
 namespace Flepper.Tests.Unit.QueryBuilder.Commands


### PR DESCRIPTION
Implements table alias on selected columns

Example:
Before: `SELECT t1.Name FROM Table1 t1`
Now: `SELECT [t1].[Name] FROM Table1 t1`


#52